### PR TITLE
minor fix to makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,11 +1,11 @@
 manuscript = no_numerical_exp_report
 references = $(wildcard *.bib)
-latexopt   = -halt-on-error -file-line-error
+latexopt   = -halt-on-error -file-line-error -shell-escape
 
 all: all-via-pdf
 
 all-via-pdf: $(manuscript).tex $(references)
-	pdflatex $(latexopt) --shell-escape $<
+	pdflatex $(latexopt) $<
 	bibtex $(manuscript).aux
 	pdflatex $(latexopt) $<
 	pdflatex $(latexopt) $<


### PR DESCRIPTION
minted requires the shell escape flag everywhere latex is run, not just the first time.